### PR TITLE
Rework vertical guides so that up / down buttons appear over the lines

### DIFF
--- a/imports/client/components/Threading.js
+++ b/imports/client/components/Threading.js
@@ -294,6 +294,7 @@ class Threading extends PureComponent {
             <span>{HOLE_LABELS[labelIndex]}</span>
           </li>
           {cells}
+          <VerticalGuides numberOfTablets={numberOfTablets} />
         </ul>
       </>
     );
@@ -356,7 +357,7 @@ class Threading extends PureComponent {
   }
 
   renderChart() {
-    const { holes, numberOfTablets } = this.props;
+    const { holes } = this.props;
     const rows = [];
     for (let i = 0; i < holes; i += 1) {
       rows.push(
@@ -372,10 +373,6 @@ class Threading extends PureComponent {
         {this.renderIncludeInTwistCalculationsButtons()}
         <div className='threading-chart-holder'>
           <ul className='threading-chart'>{rows}</ul>
-          <VerticalGuides
-            numberOfRows={holes}
-            numberOfTablets={numberOfTablets}
-          />
         </div>
       </>
     );

--- a/imports/client/components/Threading.scss
+++ b/imports/client/components/Threading.scss
@@ -54,6 +54,7 @@
     li {
       margin: 0;
       padding: 0;
+      position: relative;
     }
 
     .cell {

--- a/imports/client/components/VerticalGuides.js
+++ b/imports/client/components/VerticalGuides.js
@@ -6,7 +6,7 @@ import './VerticalGuides.scss';
 function VerticalGuides(props) {
   const verticalGuideInterval = 4;
 
-  const { numberOfRows, numberOfTablets } = props;
+  const { numberOfTablets } = props;
   const cellWidth = 33;
   const numberOfSections = numberOfTablets / verticalGuideInterval;
 
@@ -16,7 +16,7 @@ function VerticalGuides(props) {
 
   const verticalGuides = [];
   for (let i = 0; i < numberOfSections - 1; i += 1) {
-    const left = i * verticalGuideInterval * cellWidth;
+    const left = i * verticalGuideInterval * cellWidth + 5;
     const width = verticalGuideInterval * cellWidth;
 
     verticalGuides.push(
@@ -35,29 +35,23 @@ function VerticalGuides(props) {
 
   // we need to add a guide for the centre
   if (centreGuideIndex === undefined) {
-    const center = (cellWidth * numberOfTablets) / 2;
+    const center = (cellWidth * (numberOfTablets - 1)) / 2;
 
     verticalGuides.push(
       <div
         className='vertical-guide center'
         style={{
-          left: center - 5,
+          left: center,
+          width: 33,
         }}
       />,
     );
   }
 
-  return (
-    <div className='vertical-guides' style={{ height: numberOfRows * 33 }}>
-      {verticalGuides}
-    </div>
-  );
+  return <div className='vertical-guides'>{verticalGuides}</div>;
 }
 
-// known bug that eslint does not reliably detect props inside functions in a functional component
-// https://github.com/yannickcr/eslint-plugin-react/issues/885
 VerticalGuides.propTypes = {
-  numberOfRows: PropTypes.number.isRequired,
   numberOfTablets: PropTypes.number.isRequired,
 };
 

--- a/imports/client/components/VerticalGuides.scss
+++ b/imports/client/components/VerticalGuides.scss
@@ -2,22 +2,36 @@
 
 .vertical-guides {
   bottom: 0;
+  height: 33px;
   position: absolute;
-  width: 100%;
-  left: 35px;
-  opacity: 75%;
+  left: 33px;
   pointer-events: none;
-  z-index: 11;
+  opacity: 0.85;
 
   .vertical-guide {
     position: absolute;
-    border-right: 5px dotted $color-vertical-guide;
-    height: 100%;
+    height: 33px;
     margin-left: 1px; // adjust for line width
     top: 0;
 
+    // dotted line where we control the size and spacing
+    // so the dots are consistently spaced between cells
+    background-position: right;
+    background-size: 11px 11px;
+    background-repeat: repeat-y;
+    background-image: radial-gradient(
+      circle,
+      $color-vertical-guide 3px,
+      $color-vertical-guide-trans 3px
+    );
+
     &.center {
-      border-color: $color-vertical-guide-center;
+      background-position: center;
+      background-image: radial-gradient(
+        circle,
+        $color-vertical-guide-center 3px,
+        $color-vertical-guide-center-trans 3px
+      );
     }
   }
 }

--- a/imports/client/components/WeavingChart.js
+++ b/imports/client/components/WeavingChart.js
@@ -71,10 +71,12 @@ function WeavingChart(props) {
             <span>{rowLabel}</span>
           </li>
           {cells}
+          {printView && <VerticalGuides numberOfTablets={numberOfTablets} />}
         </ul>
         {!printView && (
           <div className='highlight'>
             <div className='innertube' />
+            <VerticalGuides numberOfTablets={numberOfTablets} />
             <div className='buttons'>
               <button
                 type='button'
@@ -124,13 +126,7 @@ function WeavingChart(props) {
   };
 
   const renderChart = () => {
-    const {
-      handleClickRow,
-      numberOfRows,
-      numberOfTablets,
-      printView,
-      selectedRow,
-    } = props;
+    const { handleClickRow, numberOfRows, printView, selectedRow } = props;
 
     const rows = [];
     for (let i = 0; i < numberOfRows; i += 1) {
@@ -161,10 +157,6 @@ function WeavingChart(props) {
       <div className='weaving-chart-holder'>
         {renderTabletLabels()}
         <ul className='weaving-chart'>{rows}</ul>
-        <VerticalGuides
-          numberOfRows={numberOfRows}
-          numberOfTablets={numberOfTablets}
-        />
       </div>
     );
   };

--- a/imports/client/constants/variables.scss
+++ b/imports/client/constants/variables.scss
@@ -128,8 +128,10 @@ $color-userpic-5: #c90;
 $color-row-direction: #424a6c;
 $color-row-direction-background: #fff;
 $color-row-direction-background-disabled: #ccc;
-$color-vertical-guide: #7accf9;
+$color-vertical-guide: rgb(122, 204, 249);
+$color-vertical-guide-trans: rgba(122, 204, 249, 0);
 $color-vertical-guide-center: rgb(255, 95, 95);
+$color-vertical-guide-center-trans: rgba(255, 95, 95, 0);
 
 $color-twill-design-cell-background: #fff;
 $color-twill-design-cell-border: #999;

--- a/imports/client/containers/InteractiveWeavingChart.js
+++ b/imports/client/containers/InteractiveWeavingChart.js
@@ -141,6 +141,24 @@ class InteractiveWeavingChart extends PureComponent {
     return numberOfRows - selectedRow;
   }
 
+  setSelectedRow(selectedRow) {
+    const { dispatch } = this.props;
+    const {
+      pattern: { _id },
+    } = this.context;
+
+    this.setState({
+      selectedRow,
+    });
+
+    dispatch(
+      addRecentPattern({
+        currentWeavingRow: this.getCurrentWeavingRow(selectedRow),
+        patternId: _id,
+      }),
+    );
+  }
+
   handleKeyUp(event) {
     const { history } = this.props;
     const {
@@ -164,24 +182,6 @@ class InteractiveWeavingChart extends PureComponent {
       default:
         break;
     }
-  }
-
-  setSelectedRow(selectedRow) {
-    const { dispatch } = this.props;
-    const {
-      pattern: { _id },
-    } = this.context;
-
-    this.setState({
-      selectedRow: selectedRow,
-    });
-
-    dispatch(
-      addRecentPattern({
-        currentWeavingRow: this.getCurrentWeavingRow(selectedRow),
-        patternId: _id,
-      }),
-    );
   }
 
   scrollRowIntoView() {


### PR DESCRIPTION
Vertical guides are now within the chart row so that the up / down buttons can appear in front of them. Each guide is now only the height of one row and therefore the dotted lines had to be rendered in a different way so that the spacing can be adjusted to be even across rows.