### PR TITLE
Fix issue with remove tablet

### DIFF
--- a/imports/client/components/WeavingChart.scss
+++ b/imports/client/components/WeavingChart.scss
@@ -174,6 +174,7 @@
   .tablet-labels {
     margin-left: 32px;
     overflow-x: auto;
+    pointer-events: none;
     position: absolute;
     white-space: nowrap;
     z-index: 12;

--- a/server/methods/patternEdit.js
+++ b/server/methods/patternEdit.js
@@ -1138,7 +1138,10 @@ Meteor.methods({
           update.$set[`includeInTwist.${tablet}`] = 'toBeRemoved';
         }
 
-        update.$set[`tabletGuides.${tablet}`] = 'toBeRemoved';
+        // if this is an old pattern, it may not have tabletGuides set up yet
+        if (pattern.tabletGuides) {
+          update.$set[`tabletGuides.${tablet}`] = 'toBeRemoved';
+        }
 
         // updates for weaving depend on pattern type
         switch (patternType) {
@@ -1197,9 +1200,12 @@ Meteor.methods({
           update2.$pull.includeInTwist = 'toBeRemoved';
         }
 
-        update2.$pull = {
-          tabletGuides: 'toBeRemoved',
-        };
+        // if this is an old pattern, it may not have tabletGuides set up yet
+        if (pattern.tabletGuides) {
+          update2.$pull = {
+            tabletGuides: 'toBeRemoved',
+          };
+        }
 
         update2.$set = {
           numberOfTablets: pattern.numberOfTablets - 1,


### PR DESCRIPTION
Old patterns may not have tablet guides and this causes an error when you remove a tablet. The attempt to mark the non-existent tabletGuides field creates faulty data.
The fix is to check whether the pattern has tabletGuides before attempting to remove the tablet.