### PR TITLE
Fix error in remove tablet method

### DIFF
--- a/server/methods/patternEdit.js
+++ b/server/methods/patternEdit.js
@@ -1138,7 +1138,7 @@ Meteor.methods({
           update.$set[`includeInTwist.${tablet}`] = 'toBeRemoved';
         }
 
-        // ithe pattern may not have tabletGuides set up yet
+        // the pattern may not have tabletGuides set up yet
         if (pattern.tabletGuides) {
           update.$set[`tabletGuides.${tablet}`] = 'toBeRemoved';
         }

--- a/server/methods/patternEdit.js
+++ b/server/methods/patternEdit.js
@@ -1138,7 +1138,7 @@ Meteor.methods({
           update.$set[`includeInTwist.${tablet}`] = 'toBeRemoved';
         }
 
-        // if this is an old pattern, it may not have tabletGuides set up yet
+        // ithe pattern may not have tabletGuides set up yet
         if (pattern.tabletGuides) {
           update.$set[`tabletGuides.${tablet}`] = 'toBeRemoved';
         }
@@ -1189,22 +1189,22 @@ Meteor.methods({
 
         Patterns.update({ _id }, update, { bypassCollection2: true });
 
-        const update2 = {};
+        const update2 = {}; // create the update object
 
+        // create the pull object
         // update for orientation is the same for all pattern types
         update2.$pull = {
           orientations: 'toBeRemoved',
         };
 
+        // modify the pull object and don't overwrite the previous pull instruction
         if (patternType !== 'freehand') {
           update2.$pull.includeInTwist = 'toBeRemoved';
         }
 
-        // if this is an old pattern, it may not have tabletGuides set up yet
+        // the pattern may not have tabletGuides set up yet
         if (pattern.tabletGuides) {
-          update2.$pull = {
-            tabletGuides: 'toBeRemoved',
-          };
+          update2.$pull.tabletGuides = 'toBeRemoved';
         }
 
         update2.$set = {


### PR DESCRIPTION
After adding the feature to show tablet guides, an error was introduced if you add two tablets, then remove one. The tablet guide removal "pull" mistakenly overwrote the previously-defined "pull" for orientations.

User report:
"I broke a pattern 🙈 (well, twice even: 9H6wQge9j4bw7bmPN & JHe6sgW99XDPJYHYN). Started by copying one of my patterns, added 2 cards at 26 and 2 at 2. Edited a little, then deleted cards 29 and 2. When I tried to copy the pattern, an error message popped up. When I reloaded, the pattern was toast. 🤷‍♀️ (No need to restore it, I was just doodling anyway.)"

I found that if I added two tablets and removed one, without refreshing the page or pressing 'done', then the pattern in the database showed "toBeRemoved" for one of the tablet orientations, which showed that the removal operation had not been run for orientations.