### PR TITLE
Mobile version of side menu and improvements to mobile view layout

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -7,9 +7,9 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/imports/client/components/AddToSet.js
+++ b/imports/client/components/AddToSet.js
@@ -6,11 +6,7 @@ import ReactDOM from 'react-dom';
 import { Button } from 'reactstrap';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import {
-	addPatternToSet,
-	addSet,
-	removePatternFromSet,
-} from '../modules/set';
+import { addPatternToSet, addSet, removePatternFromSet } from '../modules/set';
 import { setPatternForSetsList } from '../modules/page';
 import AppContext from '../modules/appContext';
 import AddToSetForm from '../forms/AddToSetForm';
@@ -20,170 +16,168 @@ import './AddToSet.scss';
 /* eslint-disable no-case-declarations */
 
 class AddToSet extends Component {
-	constructor(props) {
-		super(props);
+  constructor(props) {
+    super(props);
 
-		this.state = {
-			'showSetsPanel': false,
-		};
+    this.state = {
+      showSetsPanel: false,
+    };
 
-		// Add to set panel is rendered to the body element
-		// so it can be positioned within the viewport
-		this.el = document.createElement('div');
-		this.el.className = 'add-to-set-panel-holder';
-	}
+    // Add to set panel is rendered to the body element
+    // so it can be positioned within the viewport
+    this.el = document.createElement('div');
+    this.el.className = 'add-to-set-panel-holder';
+  }
 
-	componentDidMount() {
-		document.body.appendChild(this.el);
-	}
+  componentDidMount() {
+    document.body.appendChild(this.el);
+  }
 
-	componentDidUpdate(prevProps) {
-		const { patternForSetsList, patternId } = this.props;
+  componentDidUpdate(prevProps) {
+    const { patternForSetsList, patternId } = this.props;
 
-		// don't allow the panel to be open for more than one pattern at a time
-		if (prevProps.patternForSetsList === patternId
-			&& patternForSetsList !== patternId) {
-			this.setState({
-				'showSetsPanel': false,
-			});
-		}
-	}
+    // don't allow the panel to be open for more than one pattern at a time
+    if (
+      prevProps.patternForSetsList === patternId &&
+      patternForSetsList !== patternId
+    ) {
+      this.setState({
+        showSetsPanel: false,
+      });
+    }
+  }
 
-	componentWillUnmount() {
-		document.body.removeChild(this.el);
-	}
+  componentWillUnmount() {
+    document.body.removeChild(this.el);
+  }
 
-	handleClickAddToSetButton = (e) => {
-		e.preventDefault();
+  handleClickAddToSetButton = (e) => {
+    e.preventDefault();
 
-		const {
-			dispatch,
-			patternId,
-		} = this.props;
+    const { dispatch, patternId } = this.props;
 
-		this.setState({
-			'showSetsPanel': true,
-		});
+    this.setState({
+      showSetsPanel: true,
+    });
 
-		dispatch(setPatternForSetsList(patternId));
-	}
+    dispatch(setPatternForSetsList(patternId));
+  };
 
-	handleClickCancel = () => {
-		const {
-			dispatch,
-		} = this.props;
+  handleClickCancel = () => {
+    const { dispatch } = this.props;
 
-		this.setState({
-			'showSetsPanel': false,
-		});
+    this.setState({
+      showSetsPanel: false,
+    });
 
-		dispatch(setPatternForSetsList(''));
-	}
+    dispatch(setPatternForSetsList(''));
+  };
 
-	handleAddToSet = (values) => {
-		const {
-			dispatch,
-			patternId,
-		} = this.props;
-		const { namenewset } = values;
-		const { sets } = this.context;
+  handleAddToSet = (values) => {
+    const { dispatch, patternId } = this.props;
+    const { namenewset } = values;
+    const { sets } = this.context;
 
-		// analyse changes to set allocation
-		Object.keys(values).map((key) => {
-			const value = values[key];
+    // analyse changes to set allocation
+    Object.keys(values).map((key) => {
+      const value = values[key];
 
-			switch (key) {
-				// add pattern to a new set
-				case 'namenewset':
-					break;
+      switch (key) {
+        // add pattern to a new set
+        case 'namenewset':
+          break;
 
-				// existing sets, this is what we need to analyse
-				// check for changes
-				default:
-					const setId = key.split('-')[1];
-					const set = sets.find((setObj) => setObj._id === setId);
-					const patternIsInSet = set.patterns.indexOf(patternId) !== -1;
+        // existing sets, this is what we need to analyse
+        // check for changes
+        default:
+          const setId = key.split('-')[1];
+          const set = sets.find((setObj) => setObj._id === setId);
+          const patternIsInSet = set.patterns.indexOf(patternId) !== -1;
 
-					if (!patternIsInSet && value) {
-						// not currently in set: add
-						dispatch(addPatternToSet({
-							patternId,
-							setId,
-						}));
-					} else if (patternIsInSet && !value) {
-						// currently in set: remove
-						dispatch(removePatternFromSet({
-							patternId,
-							setId,
-						}));
-					}
-					break;
-			}
-		});
+          if (!patternIsInSet && value) {
+            // not currently in set: add
+            dispatch(
+              addPatternToSet({
+                patternId,
+                setId,
+              }),
+            );
+          } else if (patternIsInSet && !value) {
+            // currently in set: remove
+            dispatch(
+              removePatternFromSet({
+                patternId,
+                setId,
+              }),
+            );
+          }
+          break;
+      }
+    });
 
-		this.setState({
-			'showSetsPanel': false,
-		});
+    this.setState({
+      showSetsPanel: false,
+    });
 
-		if (namenewset !== '') {
-			dispatch(addSet({ patternId, 'name': namenewset }));
-		}
-	}
+    if (namenewset !== '') {
+      dispatch(addSet({ patternId, name: namenewset }));
+    }
+  };
 
-	render() {
-		const {
-			navBar,
-			patternId,
-			patternName,
-		} = this.props;
-		const { showSetsPanel } = this.state;
-		const { sets } = this.context;
-		const tooltip = 'Include pattern in sets';
+  render() {
+    const { navBar, patternId, patternName, isMobile } = this.props;
+    const { showSetsPanel } = this.state;
+    const { sets } = this.context;
+    const tooltip = 'Include pattern in sets';
 
-		let style = { 'backgroundImage': `url(${Meteor.absoluteUrl('/images/set_blue_64.png')}` };
+    let style = {
+      backgroundImage: `url(${Meteor.absoluteUrl('/images/set_blue_64.png')}`,
+    };
 
-		if (navBar) {
-			style = { 'backgroundImage': `url(${Meteor.absoluteUrl('/images/set_white_64.png')}` };
-		}
+    if (navBar && !isMobile) {
+      style = {
+        backgroundImage: `url(${Meteor.absoluteUrl('/images/set_white_64.png')}`,
+      };
+    }
 
-		return (
-			<>
-				<div className="add-to-set-button">
-					<Button
-						type="button"
-						onClick={this.handleClickAddToSetButton}
-						color="default"
-						title={tooltip}
-					>
-						<span
-							className="icon"
-							style={style}
-						/>
-						{navBar && <span className="d-inline d-md-none button-text nav-link">Include pattern in sets</span>}
-					</Button>
-				</div>
-				{showSetsPanel && (
-					ReactDOM.createPortal(
-						<AddToSetForm
-							handleCancel={this.handleClickCancel}
-							handleSubmit={this.handleAddToSet}
-							patternId={patternId}
-							patternName={patternName}
-							sets={sets.filter((set) => set.createdBy === Meteor.userId())}
-						/>,
-						this.el,
-					)
-				)}
-			</>
-		);
-	}
+    return (
+      <>
+        <div className='add-to-set-button'>
+          <Button
+            type='button'
+            onClick={this.handleClickAddToSetButton}
+            color='default'
+            title={tooltip}
+          >
+            <span className='icon' style={style} />
+            {navBar && (
+              <span className='d-inline d-md-none button-text nav-link'>
+                Include pattern in sets
+              </span>
+            )}
+          </Button>
+        </div>
+        {showSetsPanel &&
+          ReactDOM.createPortal(
+            <AddToSetForm
+              handleCancel={this.handleClickCancel}
+              handleSubmit={this.handleAddToSet}
+              patternId={patternId}
+              patternName={patternName}
+              sets={sets.filter((set) => set.createdBy === Meteor.userId())}
+            />,
+            this.el,
+          )}
+      </>
+    );
+  }
 }
 
 // we use connect to get dispatch but do not actually map any props
 function mapStateToProps(state) {
-	return {
-		'patternForSetsList': state.page.patternForSetsList,
-	};
+  return {
+    patternForSetsList: state.page.patternForSetsList,
+  };
 }
 
 // context is used to avoid multiple subscriptions
@@ -191,11 +185,12 @@ function mapStateToProps(state) {
 AddToSet.contextType = AppContext;
 
 AddToSet.propTypes = {
-	'dispatch': PropTypes.func.isRequired,
-	'navBar': PropTypes.bool,
-	'patternForSetsList': PropTypes.string.isRequired,
-	'patternId': PropTypes.string.isRequired,
-	'patternName': PropTypes.string.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  navBar: PropTypes.bool,
+  patternForSetsList: PropTypes.string.isRequired,
+  patternId: PropTypes.string.isRequired,
+  patternName: PropTypes.string.isRequired,
+  isMobile: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(AddToSet);

--- a/imports/client/components/MainMenu.scss
+++ b/imports/client/components/MainMenu.scss
@@ -1,4 +1,8 @@
-@import "../constants/variables";
+@import '../constants/variables';
+
+.main-menu {
+  display: none;
+}
 
 // menu and content for Home and 'listing' pages like My Patterns
 .home,
@@ -11,53 +15,140 @@
 .set,
 .user,
 .account {
-	background-color: $color-home-page-background;
+  background-color: $color-home-page-background;
 
-	.main-container {
-		max-width: unset;
-		width: unset;
-	}
+  .main-container {
+    max-width: unset;
+    width: unset;
+  }
 
-	.container {
-		max-width: 600px;
-	}
+  .container {
+    max-width: 600px;
+  }
 
-	.main-menu {
-		background-color: $color-main-menu-background;
-		float: left;
-		list-style: none;
-		padding: 16px 0;
-		position: relative;
-		top: -16px;
-		width: 200px;
+  .main-menu {
+    display: none;
+  }
 
-		li {
-			cursor: pointer;
-			float: left;
-			line-height: 2;
-			padding: 0 16px;
-			text-overflow: ellipsis;
-			white-space: pre-line;
-			width: 100%;
+  .main-menu,
+  .navbar .upload-menu,
+  .navbar .ml-auto {
+    background-color: $color-main-menu-background;
+    color: $color-text;
+    float: left;
+    list-style: none;
+    padding: 16px 0;
+    position: relative;
 
-			&.selected {
-				background-color: $color-main-menu-selected-background;
-			}
+    width: 200px;
 
-			&.section-break {
-				border-bottom: 1px solid $color-main-menu-break;
-			}
-		}
-	}
+    li {
+      cursor: pointer;
+      float: left;
+      line-height: 2;
+      padding: 0 16px;
+      text-overflow: ellipsis;
+      white-space: pre-line;
+      width: 100%;
 
-	.menu-selected-area {
-		margin-left: 200px;
-		max-width: unset;
-		width: unset;
+      &.selected {
+        background-color: $color-main-menu-selected-background;
+      }
 
-		.container {
-			margin-left: 0;
-		}
-	}
+      &.section-break {
+        border-bottom: 1px solid $color-main-menu-break;
+      }
+
+      &:hover {
+        background-color: $color-main-menu-hover-background;
+      }
+    }
+  }
+
+  .navbar .ml-auto {
+    border-bottom: 1px solid $color-main-menu-break;
+  }
+
+  .menu-selected-area {
+    margin-left: 200px;
+    max-width: unset;
+    width: unset;
+
+    .container {
+      margin-left: 0;
+    }
+  }
+
+  .menu-selected-area {
+    margin-left: 0;
+    max-width: unset;
+    width: unset;
+
+    .container {
+      margin-left: 0;
+    }
+  }
+
+  // show menu in mobile view inside the navbar mobile menu
+  .navbar .main-menu,
+  .navbar .upload-menu,
+  .navbar .ml-auto {
+    display: block;
+    padding: 0;
+    width: 100%;
+
+    .nav-link {
+      color: $color-text !important;
+      padding: 0;
+    }
+  }
+
+  // desktop view (default css is mobile)
+  @media (min-width: 768px) {
+    .main-menu {
+      display: block;
+      float: left;
+      top: -16px;
+      width: 200px;
+    }
+
+    .navbar .main-menu,
+    .navbar .upload-menu,
+    .navbar .ml-auto {
+      background-color: $color-navbar-background;
+      color: $color-navbar-color;
+      padding: 0;
+    }
+    .navbar .ml-auto {
+      border-bottom: none;
+
+      .nav-item {
+        width: unset;
+        padding: 0;
+      }
+      f .nav-link {
+        background-color: $color-navbar-background !important;
+        color: $color-navbar-color !important;
+
+        &:focus,
+        &:hover {
+          color: var(--bs-nav-link-hover-color) !important;
+        }
+      }
+    }
+
+    .navbar.ml-auto .nav-item {
+      padding: 0;
+    }
+
+    .menu-selected-area {
+      margin-left: 200px;
+      max-width: unset;
+      width: unset;
+
+      .container {
+        margin-left: 0;
+      }
+    }
+  }
 }
-

--- a/imports/client/components/MainMenu.scss
+++ b/imports/client/components/MainMenu.scss
@@ -25,48 +25,121 @@
   .container {
     max-width: 600px;
   }
+}
 
+.main-menu {
+  display: none;
+}
+
+.main-menu,
+.navbar .upload-menu,
+.navbar .ml-auto {
+  background-color: $color-main-menu-background;
+  color: $color-text;
+  float: left;
+  list-style: none;
+  padding: 16px 0;
+  position: relative;
+
+  width: 200px;
+
+  li {
+    cursor: pointer;
+    float: left;
+    line-height: 2;
+    padding: 0 16px;
+    text-overflow: ellipsis;
+    white-space: pre-line;
+    width: 100%;
+
+    &.selected {
+      background-color: $color-main-menu-selected-background;
+    }
+
+    &.section-break {
+      border-bottom: 1px solid $color-main-menu-break;
+    }
+
+    &:hover {
+      background-color: $color-main-menu-hover-background;
+    }
+  }
+}
+
+.navbar .ml-auto {
+  border-bottom: 1px solid $color-main-menu-break;
+}
+
+.menu-selected-area {
+  margin-left: 200px;
+  max-width: unset;
+  width: unset;
+
+  .container {
+    margin-left: 0;
+  }
+}
+
+.menu-selected-area {
+  margin-left: 0;
+  max-width: unset;
+  width: unset;
+
+  .container {
+    margin-left: 0;
+  }
+}
+
+// show menu in mobile view inside the navbar mobile menu
+.navbar .main-menu,
+.navbar .upload-menu,
+.navbar .ml-auto {
+  display: block;
+  padding: 0;
+  width: 100%;
+
+  .nav-link {
+    color: $color-text !important;
+    padding: 0;
+  }
+}
+
+// desktop view (default css is mobile)
+@media (min-width: 768px) {
   .main-menu {
-    display: none;
+    display: block;
+    float: left;
+    top: -16px;
+    width: 200px;
   }
 
-  .main-menu,
+  .navbar .main-menu,
   .navbar .upload-menu,
   .navbar .ml-auto {
-    background-color: $color-main-menu-background;
-    color: $color-text;
-    float: left;
-    list-style: none;
-    padding: 16px 0;
-    position: relative;
+    background-color: $color-navbar-background;
+    color: $color-navbar-color;
+    padding: 0;
+  }
+  .navbar .ml-auto {
+    border-bottom: none;
 
-    width: 200px;
+    .nav-item {
+      width: unset;
+      padding: 0;
+    }
+    f .nav-link {
+      background-color: $color-navbar-background !important;
+      color: $color-navbar-color !important;
 
-    li {
-      cursor: pointer;
-      float: left;
-      line-height: 2;
-      padding: 0 16px;
-      text-overflow: ellipsis;
-      white-space: pre-line;
-      width: 100%;
-
-      &.selected {
-        background-color: $color-main-menu-selected-background;
-      }
-
-      &.section-break {
-        border-bottom: 1px solid $color-main-menu-break;
-      }
-
+      &:focus,
       &:hover {
-        background-color: $color-main-menu-hover-background;
+        color: var(--bs-nav-link-hover-color) !important;
       }
     }
   }
 
-  .navbar .ml-auto {
-    border-bottom: 1px solid $color-main-menu-break;
+  .navbar.ml-auto .nav-item {
+    padding: 0;
   }
 
   .menu-selected-area {
@@ -76,79 +149,6 @@
 
     .container {
       margin-left: 0;
-    }
-  }
-
-  .menu-selected-area {
-    margin-left: 0;
-    max-width: unset;
-    width: unset;
-
-    .container {
-      margin-left: 0;
-    }
-  }
-
-  // show menu in mobile view inside the navbar mobile menu
-  .navbar .main-menu,
-  .navbar .upload-menu,
-  .navbar .ml-auto {
-    display: block;
-    padding: 0;
-    width: 100%;
-
-    .nav-link {
-      color: $color-text !important;
-      padding: 0;
-    }
-  }
-
-  // desktop view (default css is mobile)
-  @media (min-width: 768px) {
-    .main-menu {
-      display: block;
-      float: left;
-      top: -16px;
-      width: 200px;
-    }
-
-    .navbar .main-menu,
-    .navbar .upload-menu,
-    .navbar .ml-auto {
-      background-color: $color-navbar-background;
-      color: $color-navbar-color;
-      padding: 0;
-    }
-    .navbar .ml-auto {
-      border-bottom: none;
-
-      .nav-item {
-        width: unset;
-        padding: 0;
-      }
-      f .nav-link {
-        background-color: $color-navbar-background !important;
-        color: $color-navbar-color !important;
-
-        &:focus,
-        &:hover {
-          color: var(--bs-nav-link-hover-color) !important;
-        }
-      }
-    }
-
-    .navbar.ml-auto .nav-item {
-      padding: 0;
-    }
-
-    .menu-selected-area {
-      margin-left: 200px;
-      max-width: unset;
-      width: unset;
-
-      .container {
-        margin-left: 0;
-      }
     }
   }
 }

--- a/imports/client/components/MainMenu.scss
+++ b/imports/client/components/MainMenu.scss
@@ -1,8 +1,8 @@
 @import '../constants/variables';
 
-.main-menu {
-  display: none;
-}
+// ====================
+// MOBILE-FIRST STYLES (DEFAULT)
+// ====================
 
 // menu and content for Home and 'listing' pages like My Patterns
 .home,
@@ -27,20 +27,15 @@
   }
 }
 
+// Main menu - hidden by default on mobile, shown inside navbar collapse
 .main-menu {
   display: none;
-}
-
-.main-menu,
-.navbar .upload-menu,
-.navbar .ml-auto {
   background-color: $color-main-menu-background;
   color: $color-text;
   float: left;
   list-style: none;
   padding: 16px 0;
   position: relative;
-
   width: 200px;
 
   li {
@@ -66,20 +61,7 @@
   }
 }
 
-.navbar .ml-auto {
-  border-bottom: 1px solid $color-main-menu-break;
-}
-
-.menu-selected-area {
-  margin-left: 200px;
-  max-width: unset;
-  width: unset;
-
-  .container {
-    margin-left: 0;
-  }
-}
-
+// Menu selected area - mobile default (no left margin)
 .menu-selected-area {
   margin-left: 0;
   max-width: unset;
@@ -90,22 +72,59 @@
   }
 }
 
-// show menu in mobile view inside the navbar mobile menu
-.navbar .main-menu,
-.navbar .upload-menu,
-.navbar .ml-auto {
-  display: block;
-  padding: 0;
-  width: 100%;
-
-  .nav-link {
-    color: $color-text !important;
+// Navbar menus - styled for mobile view inside collapsed navbar
+.navbar {
+  .main-menu,
+  .upload-menu,
+  .ml-auto {
+    background-color: $color-main-menu-background;
+    color: $color-text;
+    display: block;
+    float: left;
+    list-style: none;
     padding: 0;
+    position: relative;
+    width: 100%;
+
+    .nav-link {
+      color: $color-text !important;
+      padding: 0;
+    }
+
+    li {
+      cursor: pointer;
+      float: left;
+      line-height: 2;
+      padding: 0 16px;
+      text-overflow: ellipsis;
+      white-space: pre-line;
+      width: 100%;
+
+      &.selected {
+        background-color: $color-main-menu-selected-background;
+      }
+
+      &.section-break {
+        border-bottom: 1px solid $color-main-menu-break;
+      }
+
+      &:hover {
+        background-color: $color-main-menu-hover-background;
+      }
+    }
+  }
+
+  .ml-auto {
+    border-bottom: 1px solid $color-main-menu-break;
   }
 }
 
-// desktop view (default css is mobile)
+// ====================
+// DESKTOP STYLES
+// ====================
+
 @media (min-width: 768px) {
+  // Show main menu as sidebar
   .main-menu {
     display: block;
     float: left;
@@ -113,35 +132,7 @@
     width: 200px;
   }
 
-  .navbar .main-menu,
-  .navbar .upload-menu,
-  .navbar .ml-auto {
-    background-color: $color-navbar-background;
-    color: $color-navbar-color;
-    padding: 0;
-  }
-  .navbar .ml-auto {
-    border-bottom: none;
-
-    .nav-item {
-      width: unset;
-      padding: 0;
-    }
-    f .nav-link {
-      background-color: $color-navbar-background !important;
-      color: $color-navbar-color !important;
-
-      &:focus,
-      &:hover {
-        color: var(--bs-nav-link-hover-color) !important;
-      }
-    }
-  }
-
-  .navbar.ml-auto .nav-item {
-    padding: 0;
-  }
-
+  // Adjust content area to account for sidebar
   .menu-selected-area {
     margin-left: 200px;
     max-width: unset;
@@ -149,6 +140,36 @@
 
     .container {
       margin-left: 0;
+    }
+  }
+
+  // Reset navbar menus to navbar style (not sidebar style)
+  .navbar {
+    .main-menu,
+    .upload-menu,
+    .ml-auto {
+      background-color: $color-navbar-background;
+      color: $color-navbar-color;
+      padding: 0;
+
+      .nav-link {
+        background-color: $color-navbar-background !important;
+        color: $color-navbar-color !important;
+
+        &:focus,
+        &:hover {
+          color: var(--bs-nav-link-hover-color) !important;
+        }
+      }
+    }
+
+    .ml-auto {
+      border-bottom: none;
+
+      .nav-item {
+        width: unset;
+        padding: 0;
+      }
     }
   }
 }

--- a/imports/client/components/Navbar.js
+++ b/imports/client/components/Navbar.js
@@ -22,6 +22,7 @@ import AppContext from '../modules/appContext';
 import Search from './Search';
 import UploadPatternForm from '../forms/UploadPatternForm';
 import AddToSet from './AddToSet';
+import MainMenu from '../components/MainMenu';
 import './Navbar.scss';
 import { iconColors } from '../../modules/parameters';
 
@@ -122,7 +123,7 @@ class Navbar extends Component {
       searchTerm,
       username,
     } = this.props;
-
+    console.log('*** isMobile:', this.context.isMobile);
     if (maintenanceMode) {
       return (
         <nav className='navbar navbar-expand-md navbar-dark'>
@@ -143,7 +144,7 @@ class Navbar extends Component {
 
     const { showDropdown, showUploadPatternForm } = this.state;
 
-    const { pattern, patternId } = this.context;
+    const { pattern, patternId, isMobile } = this.context;
 
     let isOwner = false;
 
@@ -291,37 +292,39 @@ class Navbar extends Component {
 
     return (
       <nav className='nav navbar navbar-expand-md navbar-dark'>
-        {showUploadPatternForm && this.renderUploadPatternForm()}
-        <Link className='navbar-brand' to='/'>
-          <span
-            className='logo'
-            style={{
-              backgroundImage: `url(${Meteor.absoluteUrl('/images/logo.png')}`,
-            }}
+        <div className='navbar-main'>
+          {showUploadPatternForm && this.renderUploadPatternForm()}
+          <Link className='navbar-brand' to='/'>
+            <span
+              className='logo'
+              style={{
+                backgroundImage: `url(${Meteor.absoluteUrl('/images/logo.png')}`,
+              }}
+            />
+            Twisted Threads
+          </Link>
+          <Search
+            dispatch={dispatch}
+            history={history}
+            isSearching={isSearching}
+            searchTerm={searchTerm}
           />
-          Twisted Threads
-        </Link>
-        <Search
-          dispatch={dispatch}
-          history={history}
-          isSearching={isSearching}
-          searchTerm={searchTerm}
-        />
-        {myPatternsLink}
-        <button
-          className='navbar-toggler'
-          type='button'
-          data-toggle='collapse'
-          data-target='#navbarSupportedContent'
-          aria-controls='navbarSupportedContent'
-          aria-expanded='false'
-          aria-label='Toggle navigation'
-          onClick={(e) => {
-            this.showDropdown(e);
-          }}
-        >
-          <span className='navbar-toggler-icon' />
-        </button>
+          {myPatternsLink}
+          <button
+            className='navbar-toggler'
+            type='button'
+            data-toggle='collapse'
+            data-target='#navbarSupportedContent'
+            aria-controls='navbarSupportedContent'
+            aria-expanded='false'
+            aria-label='Toggle navigation'
+            onClick={(e) => {
+              this.showDropdown(e);
+            }}
+          >
+            <span className='navbar-toggler-icon' />
+          </button>
+        </div>
         <div
           className={`collapse navbar-collapse ${showDropdown ? 'show' : ''}`}
           id='navbarSupportedContent'
@@ -329,6 +332,7 @@ class Navbar extends Component {
           {uploadMenu}
           {showPatternMenu && patternMenu}
           {isAuthenticated ? authLinks : guestLinks}
+          {this.context.isMobile && <MainMenu />}
         </div>
       </nav>
     );

--- a/imports/client/components/Navbar.js
+++ b/imports/client/components/Navbar.js
@@ -233,6 +233,7 @@ class Navbar extends Component {
             navBar={true}
             patternId={patternId}
             patternName={pattern.name}
+            isMobile={isMobile}
           />
         </>
       );

--- a/imports/client/components/Navbar.js
+++ b/imports/client/components/Navbar.js
@@ -123,7 +123,7 @@ class Navbar extends Component {
       searchTerm,
       username,
     } = this.props;
-    console.log('*** isMobile:', this.context.isMobile);
+
     if (maintenanceMode) {
       return (
         <nav className='navbar navbar-expand-md navbar-dark'>

--- a/imports/client/components/Navbar.scss
+++ b/imports/client/components/Navbar.scss
@@ -1,80 +1,133 @@
 @import '../constants/variables';
 
 .navbar {
-	--bs-navbar-padding-x: 0.5rem !important;
-	background: $color-navbar-background;
-	color: $color-navbar-color;
+  --bs-navbar-padding-x: 0;
+  background: $color-navbar-background;
+  color: $color-navbar-color;
 
-	.pattern-menu,
-	.upload-menu {
-		button {
-			background-color: transparent;
-			border-color: transparent;
+  .navbar-main {
+    padding: 0.5rem;
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
 
-			&:focus {
-				outline: 1px dotted $color-navbar-focus;
-			}
+  .pattern-menu,
+  .upload-menu {
+    button {
+      background-color: transparent;
+      border-color: transparent;
+      color: $color-text;
+      padding-left: 0;
 
-			svg {
-				color: $color-navbar-color !important;
-			}
-		}
-	}
+      &:focus {
+        outline: 1px dotted $color-navbar-focus;
+      }
 
-	.button-text {
-		margin-left: 8px;
-	}
+      svg {
+        color: $color-text !important;
+      }
+    }
+  }
 
-	.logo {
-		background-size: 32px 32px;
-		float: left;
-		font-weight: bold;
-		height: 32px;
-		line-height: 32px;
-		margin: 0 8px 0 0;
-		width: 32px;
-	}
+  .button-text {
+    margin-left: 8px;
+    color: $color-text !important;
+  }
+
+  .logo {
+    background-size: 32px 32px;
+    float: left;
+    font-weight: bold;
+    height: 32px;
+    line-height: 32px;
+    margin: 0 8px 0 0;
+    width: 32px;
+  }
 }
 
 .navbar-brand,
 .nav-link {
-	color: $color-navbar-color !important;
-
-	&:hover {
-		color: $color-navbar-hover !important;
-	}
+  color: $color-navbar-color !important;
 }
 
+// desktop view (default css is mobile)
 @media (min-width: 768px) {
-	.navbar {
-		--bs-navbar-padding-x: 1rem !important;
-	}
+  .navbar {
+    --bs-navbar-padding-x: 1rem !important;
 
-	.nav-link {
-		padding: 0.5rem 1rem !important;
-	}
+    .navbar-main {
+      padding: 0;
+      display: inline-flex;
+      width: auto;
+      white-space: nowrap;
+    }
+
+    .pattern-menu,
+    .upload-menu {
+      .nav-link {
+        color: $color-navbar-color !important;
+
+        &:focus,
+        &:hover {
+          color: $color-navbar-hover !important;
+        }
+      }
+
+      button {
+        background-color: $color-navbar-background;
+        color: $color-navbar-color;
+
+        &:focus {
+          outline: 1px dotted $color-navbar-focus;
+        }
+
+        svg {
+          color: $color-navbar-color !important;
+        }
+      }
+
+      .button-text {
+        color: $color-navbar-color !important;
+      }
+    }
+
+    .nav-link {
+      padding: 0.5rem 1rem !important;
+
+      &:hover {
+        color: $color-navbar-hover !important;
+      }
+    }
+  }
 }
 
 .nav-link {
-	padding-left: 0;
-	padding-right: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .navbar-collapse {
-	justify-content: space-between;
+  justify-content: space-between;
 }
 
 .nav-item {
-	button {
-		width: auto;
+  button {
+    width: auto;
 
-		.icon {
-			margin-right: 0;
-		}
-	}
+    .icon {
+      margin-right: 0;
+    }
+  }
 }
 
 .navbar-brand {
-	font-size: 0.8rem;
-	font-weight: bold;
+  font-size: 0.8rem;
+  font-weight: bold;
+
+  &:focus,
+  &:hover {
+    color: $color-navbar-hover !important;
+  }
 }

--- a/imports/client/components/Navbar.scss
+++ b/imports/client/components/Navbar.scss
@@ -54,8 +54,29 @@
 
 // desktop view (default css is mobile)
 @media (min-width: 768px) {
+  .navbar-collapse {
+    align-items: center;
+    flex-basis: 100%;
+    flex-grow: 1;
+    justify-content: space-between;
+  }
+
   .navbar {
     --bs-navbar-padding-x: 1rem !important;
+
+    .ml-auto {
+      width: auto;
+      .nav-item,
+      .nav-link {
+        color: $color-navbar-color !important;
+
+        &:focus,
+        &:hover {
+          color: $color-navbar-hover !important;
+          background-color: unset;
+        }
+      }
+    }
 
     .navbar-main {
       padding: 0;
@@ -66,18 +87,32 @@
 
     .pattern-menu,
     .upload-menu {
-      .nav-link {
+      width: auto;
+
+      .navbar-nav {
+        display: flex;
+        width: auto;
+      }
+
+      .nav-link,
+      .nav-item {
         color: $color-navbar-color !important;
 
         &:focus,
         &:hover {
           color: $color-navbar-hover !important;
+          background-color: unset;
         }
+      }
+
+      .nav-item {
+        width: auto;
       }
 
       button {
         background-color: $color-navbar-background;
         color: $color-navbar-color;
+        padding: 6px;
 
         &:focus {
           outline: 1px dotted $color-navbar-focus;

--- a/imports/client/components/Navbar.scss
+++ b/imports/client/components/Navbar.scss
@@ -26,7 +26,7 @@
       }
 
       svg {
-        color: $color-text !important;
+        color: $color-navbar-background !important;
       }
     }
   }
@@ -97,6 +97,7 @@
       .nav-link,
       .nav-item {
         color: $color-navbar-color !important;
+        padding: 0;
 
         &:focus,
         &:hover {
@@ -112,7 +113,7 @@
       button {
         background-color: $color-navbar-background;
         color: $color-navbar-color;
-        padding: 6px;
+        padding: 6px 12px;
 
         &:focus {
           outline: 1px dotted $color-navbar-focus;

--- a/imports/client/components/Navbar.scss
+++ b/imports/client/components/Navbar.scss
@@ -1,5 +1,9 @@
 @import '../constants/variables';
 
+// ====================
+// MOBILE-FIRST STYLES (DEFAULT)
+// ====================
+
 .navbar {
   --bs-navbar-padding-x: 0;
   background: $color-navbar-background;
@@ -47,36 +51,44 @@
   }
 }
 
-.navbar-brand,
-.nav-link {
+.navbar-brand {
   color: $color-navbar-color !important;
+  font-size: 0.8rem;
+  font-weight: bold;
+
+  &:focus,
+  &:hover {
+    color: $color-navbar-hover !important;
+  }
 }
 
-// desktop view (default css is mobile)
-@media (min-width: 768px) {
-  .navbar-collapse {
-    align-items: center;
-    flex-basis: 100%;
-    flex-grow: 1;
-    justify-content: space-between;
-  }
+.nav-link {
+  color: $color-navbar-color !important;
+  padding-left: 0;
+  padding-right: 0;
+}
 
+.navbar-collapse {
+  justify-content: space-between;
+}
+
+.nav-item {
+  button {
+    width: auto;
+
+    .icon {
+      margin-right: 0;
+    }
+  }
+}
+
+// ====================
+// DESKTOP STYLES
+// ====================
+
+@media (min-width: 768px) {
   .navbar {
     --bs-navbar-padding-x: 1rem !important;
-
-    .ml-auto {
-      width: auto;
-      .nav-item,
-      .nav-link {
-        color: $color-navbar-color !important;
-
-        &:focus,
-        &:hover {
-          color: $color-navbar-hover !important;
-          background-color: unset;
-        }
-      }
-    }
 
     .navbar-main {
       padding: 0;
@@ -94,8 +106,8 @@
         width: auto;
       }
 
-      .nav-link,
       .nav-item {
+        width: auto;
         color: $color-navbar-color !important;
         padding: 0;
 
@@ -106,8 +118,15 @@
         }
       }
 
-      .nav-item {
-        width: auto;
+      .nav-link {
+        color: $color-navbar-color !important;
+        padding: 0;
+
+        &:focus,
+        &:hover {
+          color: $color-navbar-hover !important;
+          background-color: unset;
+        }
       }
 
       button {
@@ -136,34 +155,27 @@
         color: $color-navbar-hover !important;
       }
     }
-  }
-}
 
-.nav-link {
-  padding-left: 0;
-  padding-right: 0;
-}
+    .ml-auto {
+      width: auto;
 
-.navbar-collapse {
-  justify-content: space-between;
-}
+      .nav-item,
+      .nav-link {
+        color: $color-navbar-color !important;
 
-.nav-item {
-  button {
-    width: auto;
-
-    .icon {
-      margin-right: 0;
+        &:focus,
+        &:hover {
+          color: $color-navbar-hover !important;
+          background-color: unset;
+        }
+      }
     }
   }
-}
 
-.navbar-brand {
-  font-size: 0.8rem;
-  font-weight: bold;
-
-  &:focus,
-  &:hover {
-    color: $color-navbar-hover !important;
+  .navbar-collapse {
+    align-items: center;
+    flex-basis: 100%;
+    flex-grow: 1;
+    justify-content: space-between;
   }
 }

--- a/imports/client/constants/variables.scss
+++ b/imports/client/constants/variables.scss
@@ -115,6 +115,7 @@ $color-search-info: #999;
 
 $color-main-menu-background: #fff;
 $color-main-menu-selected-background: #ccc;
+$color-main-menu-hover-background: #eee;
 $color-main-menu-break: #ccc;
 
 $color-pattern-list-preview: #666;

--- a/imports/client/containers/User.scss
+++ b/imports/client/containers/User.scss
@@ -1,62 +1,62 @@
-@import "../constants/variables";
+@import '../constants/variables';
 
 .user {
-	background-color: $color-home-page-background;
+  background-color: $color-home-page-background;
 
-	.main-container {
-		max-width: unset;
-		width: unset;
-	}
+  .main-container {
+    max-width: unset;
+    width: unset;
+  }
 
-	.add-controls {
-		margin-bottom: 8px;
-	}
+  .add-controls {
+    margin-bottom: 8px;
+  }
 
-	h1 {
-		.icon {
-			background-position: left top;
-			background-repeat: no-repeat;
-			background-size: 32px 32px;
-			content: "";
-			float: left;
-			height: 32px;
-			margin: 0 8px 0 0;
-			width: 32px;
-		}
-	}
+  h1 {
+    .icon {
+      background-position: left top;
+      background-repeat: no-repeat;
+      background-size: 32px 32px;
+      content: '';
+      float: left;
+      height: 32px;
+      margin: 0 8px 0 0;
+      width: 32px;
+    }
+  }
 
-	.container {
-		margin-left: 15px;
-		max-width: 600px;
-	}
+  .container {
+    padding-left: 15px;
+    max-width: 600px;
+  }
 
-	.pattern-list-holder {
-		max-width: unset;
-		width: unset;
-	}
+  .pattern-list-holder {
+    max-width: unset;
+    width: unset;
+  }
 
-	.tablet-filter-form {
-		padding-left: 0;
-	}
+  .tablet-filter-form {
+    padding-left: 0;
+  }
 
-	.editable-text {
-		clear: none;
+  .editable-text {
+    clear: none;
 
-		form {
-			clear: none;
-		}
+    form {
+      clear: none;
+    }
 
-		.field-value {
-			clear: none;
-		}
-	}
+    .field-value {
+      clear: none;
+    }
+  }
 
-	.sets-list {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-evenly;
-		margin-left: 0;
-		margin-right: 0;
-		padding: 8px;
-	}
+  .sets-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-evenly;
+    margin-left: 0;
+    margin-right: 0;
+    padding: 8px;
+  }
 }

--- a/imports/client/forms/UploadPatternForm.js
+++ b/imports/client/forms/UploadPatternForm.js
@@ -8,116 +8,113 @@ import './UploadPatternForm.scss';
 // timeout enables a form that submits immediately and validates (setFieldValue is async)
 
 const validate = (values) => {
-	const errors = {};
+  const errors = {};
 
-	if (!values.selectFile) {
-		errors.selectFile = 'A file must be selected';
-	} else {
-		// there's no reliable way to check file type
-		// we'll check for valid data later
-		const { name, size } = values.selectFile;
+  if (!values.selectFile) {
+    errors.selectFile = 'A file must be selected';
+  } else {
+    // there's no reliable way to check file type
+    // we'll check for valid data later
+    const { name, size } = values.selectFile;
 
-		if (size > 1000000) {
-			errors.selectFile = 'File size must be < 1000000';
-		} else if (!name || name === '') {
-			errors.selectFile = 'File must have a name';
-		}
-	}
+    if (size > 1000000) {
+      errors.selectFile = 'File size must be < 1000000';
+    } else if (!name || name === '') {
+      errors.selectFile = 'File must have a name';
+    }
+  }
 
-	return errors;
+  return errors;
 };
 
 const UploadPatternForm = (props) => {
-	const { handleClose, handleSubmit } = props;
+  const { handleClose, handleSubmit } = props;
 
-	const formik = useFormik({
-		initialValues: {
-			selectFile: '',
-		},
-		validate,
-		onSubmit: (values) => {
-			global.touchedUploadPatternInput = null;
-			handleSubmit(values);
-		},
-	});
+  const formik = useFormik({
+    initialValues: {
+      selectFile: '',
+    },
+    validate,
+    onSubmit: (values) => {
+      global.touchedUploadPatternInput = null;
+      handleSubmit(values);
+    },
+  });
 
-	const { setFieldValue } = formik;
+  const { setFieldValue } = formik;
 
-	const onChange = (event) => {
-		if (event.currentTarget.files.length !== 0) {
-			const selectFile = event.currentTarget.files[0];
-			setFieldValue('selectFile', selectFile);
-			global.touchedUploadPatternInput = 'touched'; // we don't want to show errors when the user opens the file picker
-			// so mark the input as touched only when the user makes a selection
+  const onChange = (event) => {
+    if (event.currentTarget.files.length !== 0) {
+      const selectFile = event.currentTarget.files[0];
+      setFieldValue('selectFile', selectFile);
+      global.touchedUploadPatternInput = 'touched'; // we don't want to show errors when the user opens the file picker
+      // so mark the input as touched only when the user makes a selection
 
-			setTimeout(() => {
-				formik.handleSubmit();
-			}, 50);
-		}
-	};
+      setTimeout(() => {
+        formik.handleSubmit();
+      }, 50);
+    }
+  };
 
-	const onClickClose = () => {
-		global.touchedUploadPatternInput = null;
-		handleClose();
-	};
+  const onClickClose = () => {
+    global.touchedUploadPatternInput = null;
+    handleClose();
+  };
 
-	return (
-		<div className='upload-pattern-form'>
-			<form onSubmit={formik.handleSubmit}>
-				<Button
-					type='button'
-					className='btn-close'
-					aria-label='Close'
-					title='Close'
-					onClick={onClickClose}
-				/>
-				<div className='form-group'>
-					<h3>Upload pattern from file</h3>
-					<p>Supported file types:</p>
-					<ul>
-						<li>Twisted Threads version 2 (*.twt)</li>
-						<li>Guntram&apos;s Tablet Weaving Thingy (*.gtt)</li>
-					</ul>
-					<p>
-						At present, the only supported GTT pattern types are Threaded and
-						Broken Twill.
-					</p>
-					<label htmlFor='selectFile'>
-						Select a pattern file:
-						<input
-							accept='text/plain, .txt, .gtt, .twt'
-							className={`form-control ${
-								global.touchedUploadPatternInput && formik.errors.selectFile
-									? 'is-invalid'
-									: ''
-							}`}
-							id='selectFile'
-							name='selectFile'
-							type='file'
-							onChange={onChange}
-							onBlur={formik.handleBlur}
-						/>
-						{global.touchedUploadPatternInput && formik.errors.selectFile ? (
-							<div className='invalid-feedback invalid'>
-								{formik.errors.selectFile}
-							</div>
-						) : null}
-					</label>
-				</div>
-				<Button
-					type='submit'
-					color='primary'
-				>
-					Import pattern
-				</Button>
-			</form>
-		</div>
-	);
+  return (
+    <div className='upload-pattern-form'>
+      <form onSubmit={formik.handleSubmit}>
+        <Button
+          type='button'
+          className='btn-close'
+          aria-label='Close'
+          title='Close'
+          onClick={onClickClose}
+        />
+        <div className='form-group'>
+          <h3>Upload pattern from file</h3>
+          <p>Supported file types:</p>
+          <ul>
+            <li>Twisted Threads version 2 (*.twt)</li>
+            <li>Guntram&apos;s Tablet Weaving Thingy (*.gtt)</li>
+          </ul>
+          <p>
+            At present, the only supported GTT pattern types are Threaded and
+            Broken Twill.
+          </p>
+          <label htmlFor='selectFile'>
+            Select a pattern file:
+            <input
+              accept='text/plain, .txt, .gtt, .twt'
+              className={`form-control ${
+                global.touchedUploadPatternInput && formik.errors.selectFile
+                  ? 'is-invalid'
+                  : ''
+              }`}
+              id='selectFile'
+              name='selectFile'
+              type='file'
+              onChange={onChange}
+              onBlur={formik.handleBlur}
+            />
+            {global.touchedUploadPatternInput && formik.errors.selectFile ? (
+              <div className='invalid-feedback invalid'>
+                {formik.errors.selectFile}
+              </div>
+            ) : null}
+          </label>
+        </div>
+        <Button type='submit' color='primary'>
+          Import pattern
+        </Button>
+      </form>
+    </div>
+  );
 };
 // accept="text/plain, .txt, .gtt, .twt"
 UploadPatternForm.propTypes = {
-	handleClose: PropTypes.func.isRequired,
-	handleSubmit: PropTypes.func.isRequired,
+  handleClose: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
 };
 
 export default UploadPatternForm;

--- a/imports/client/forms/UploadPatternForm.scss
+++ b/imports/client/forms/UploadPatternForm.scss
@@ -1,34 +1,61 @@
 @import '../constants/variables';
 
+// ====================
+// MOBILE-FIRST STYLES (DEFAULT)
+//
+
 .upload-pattern-form {
-	color: $color-text;
-	left: 50%;
-	position: absolute;
-	top: 100px;
-	width: 350px;
-	z-index: 100;
+  color: $color-text;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 100;
 
-	form {
-		background: $color-panel-background;
-		border: 1px solid $color-panel-border;
-		border-radius: 4px;
-		margin-left: -50%;
-		padding: 8px;
-	}
+  form {
+    background: $color-panel-background;
+    border: 1px solid $color-panel-border;
+    border-radius: 4px;
+    margin: 6px;
+    padding: 8px;
 
-	label {
-		font-size: 0;
+    p {
+      white-space: normal;
+      word-wrap: break-word;
+    }
+  }
 
-		.invalid {
-			font-size: 1rem;
-		}
-	}
+  label {
+    font-size: 0;
 
-	.btn-close {
-		float: right;
-	}
+    .invalid {
+      font-size: 1rem;
+    }
+  }
 
-	[type='submit'] {
-		display: none;
-	}
+  .btn-close {
+    float: right;
+  }
+
+  [type='submit'] {
+    display: none;
+  }
+}
+
+// ====================
+// DESKTOP STYLES
+// ====================
+
+@media (min-width: 768px) {
+  .upload-pattern-form {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    top: 100px;
+
+    form {
+      width: 500px;
+      margin: 0;
+    }
+  }
 }

--- a/imports/modules/parameters.js
+++ b/imports/modules/parameters.js
@@ -372,3 +372,5 @@ export const PATTERN_AS_TEXT_FIELDS = [
     required: true,
   },
 ];
+
+export const MOBILE_BREAKPOINT = 768;


### PR DESCRIPTION
- Added a mobile version of the sidebar menu so that it doesn't take up screen width in mobile view.
- Added a helper function that detects mobile viewport programmatically so HTML structure can be changed dynamically.
- Fixed a couple of elements that extended beyond the screen width and may have caused the issues with squashed content on some devices. This was caused by the 'container' class adding width: 100vw to elements that also had margin.

New mobile layout, menu closed:
<img width="670" height="1058" alt="Mobile 1" src="https://github.com/user-attachments/assets/3e769cfb-3e02-440e-9c26-f31cc0b45b99" />

New mobile layout, menu open:
<img width="670" height="1058" alt="Mobile 2" src="https://github.com/user-attachments/assets/7702ecf7-767c-4044-891c-a64c1c9f14ca" />

It is hoped this will fix https://github.com/Shelagh-Lewins/twisted-threads-2/issues/89.
