### PR TITLE
fix bug with Add Rows. Disable Add Rows when at max number of rows. F…

### DIFF
--- a/imports/client/components/PatternPreview.js
+++ b/imports/client/components/PatternPreview.js
@@ -266,6 +266,17 @@ class PatternPreview extends Component {
         break;
     }
 
+    // scale the preview to fit on a printed page
+    // otherwise it gets pushed to a new page and separarated from necessary text
+    if (printView) {
+      const targetPageHeight = 900; // usable px height on A4/letter after margins and header
+      const scale = Math.min(1, targetPageHeight / imageHeight);
+      wrapperStyle = {
+        ...wrapperStyle,
+        zoom: scale,
+      };
+    }
+
     // /////////////
     // render the preview
     // reverse order of tablets if showing back of band

--- a/imports/client/components/VerticalGuides.scss
+++ b/imports/client/components/VerticalGuides.scss
@@ -18,11 +18,23 @@
     width: 33px;
     margin-left: 1px; // adjust for line width
     top: 0;
+    background-color: transparent;
 
     @include verticalGuide();
 
     &.center {
       @include verticalGuideCenter();
     }
+  }
+}
+
+@media print {
+  // Browsers strip background images (including radial-gradient used by the verticalGuide mixin)
+// when printing. print-color-adjust: exact prevents this, ensuring the guide lines
+// remain transparent rather than rendering as solid white boxes.
+  .vertical-guide {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    background-color: transparent !important;
   }
 }

--- a/imports/client/containers/PrintView.js
+++ b/imports/client/containers/PrintView.js
@@ -199,28 +199,6 @@ class PrintView extends PureComponent {
             {/* if navigating from the home page, the pattern summary is in MiniMongo before Tracker sets isLoading to true. This doesn't include the detail fields so we need to prevent errors. */}
             {pattern.patternDesign && pattern.previewOrientation && (
               <>
-                <h2>Woven band</h2>
-                <TwistCalculationHints
-                  canEdit={false}
-                  includeInTwist={includeInTwist}
-                  patternIsTwistNeutral={patternIsTwistNeutral}
-                  patternType={patternType}
-                  patternWillRepeat={patternWillRepeat}
-                  previewOrientation={previewOrientation}
-                  printView={true}
-                  repeats={getNumberOfRepeats(numberOfRows)}
-                />
-                <PatternPreview
-                  dispatch={dispatch}
-                  holes={holes}
-                  numberOfRows={numberOfRows}
-                  numberOfTablets={numberOfTablets}
-                  palette={palette}
-                  pattern={pattern}
-                  patternWillRepeat={patternWillRepeat}
-                  printView={true}
-                  totalTurnsByTablet={totalTurnsByTablet}
-                />
                 {weavingInstructions}
                 {weavingNotes && weavingNotes !== '' && (
                   <>
@@ -246,6 +224,28 @@ class PrintView extends PureComponent {
                   </>
                 )}
                 <Notation />
+                <h2 className='woven-band-header'>Woven band</h2>
+                <TwistCalculationHints
+                  canEdit={false}
+                  includeInTwist={includeInTwist}
+                  patternIsTwistNeutral={patternIsTwistNeutral}
+                  patternType={patternType}
+                  patternWillRepeat={patternWillRepeat}
+                  previewOrientation={previewOrientation}
+                  printView={true}
+                  repeats={getNumberOfRepeats(numberOfRows)}
+                />
+                <PatternPreview
+                  dispatch={dispatch}
+                  holes={holes}
+                  numberOfRows={numberOfRows}
+                  numberOfTablets={numberOfTablets}
+                  palette={palette}
+                  pattern={pattern}
+                  patternWillRepeat={patternWillRepeat}
+                  printView={true}
+                  totalTurnsByTablet={totalTurnsByTablet}
+                />
               </>
             )}
           </>

--- a/imports/client/containers/PrintView.scss
+++ b/imports/client/containers/PrintView.scss
@@ -70,3 +70,9 @@ body {
 		}
 	}
 }
+
+@media print {
+	.woven-band-header {
+		break-before: page;
+	}
+}

--- a/imports/client/forms/AddRowsForm.js
+++ b/imports/client/forms/AddRowsForm.js
@@ -54,6 +54,7 @@ const AddRowsForm = (props) => {
 	const stepNRows = rowsInPairs(patternType) ? 2 : 1;
 	const stepInsertAt = rowsInPairs(patternType) ? 2 : 1;
 	const minNRows = rowsInPairs(patternType) ? 2 : 1;
+	const cannotAddRows = numberOfRows >= MAX_ROWS;
 
 	const formik = useFormik({
 		'initialValues': {
@@ -99,6 +100,7 @@ const AddRowsForm = (props) => {
 							onChange={formik.handleChange}
 							onBlur={formik.handleBlur}
 							value={formik.values.insertNRows}
+							 disabled={cannotAddRows} 
 						/>
 						{formik.touched.insertNRows && formik.errors.insertNRows ? (
 							<div className="invalid-feedback invalid">{formik.errors.insertNRows}</div>
@@ -119,13 +121,14 @@ const AddRowsForm = (props) => {
 							onChange={formik.handleChange}
 							onBlur={formik.handleBlur}
 							value={formik.values.insertRowsAt}
+							 disabled={cannotAddRows} 
 						/>
 						{formik.touched.tablets && formik.errors.tablets ? (
 							<div className="invalid-feedback invalid">{formik.errors.tablets}</div>
 						) : null}
 					</label>
 					<div className="controls">
-						<Button type="submit" color="primary">Add rows</Button>
+						<Button disabled={cannotAddRows} type="submit" color="primary">Add rows</Button>
 					</div>
 				</div>
 			</form>

--- a/imports/server/modules/utils.js
+++ b/imports/server/modules/utils.js
@@ -40,7 +40,7 @@ export const validHolesCheck = Match.Where((x) => {
 export const validRowsCheck = Match.Where((x) => {
   check(x, Match.Integer);
 
-  return x >= 0 && x < MAX_ROWS;
+  return x >= 0 && x <= MAX_ROWS;
 });
 
 export const validTabletsCheck = Match.Where((x) => {


### PR DESCRIPTION
### What has changed
- Fixed bug with Max Rows (you could add one more row than is valid) and disabled the Add Rows button when Max Rows is reached.
- Fix css bug in print view so vertical guides have transparent background
- Moved woven band to end of Print View so it can be easily omitted and also so it won't run over into any other elements
- Force a page break before woven band so we know there's a full page available
- Scale woven band in Print View to a max of 900 pixels so it should fit on Letter / A4 without triggering a page break

Issue with vertical guide - has white background
<img width="1751" height="1043" alt="print view - vertical guide bug" src="https://github.com/user-attachments/assets/c2fb97cf-8adf-46c1-bf17-63a98bbe4f49" />

Issue with print view - woven band SVG is pushed to new page
<img width="1854" height="1152" alt="Print view - woven band issue" src="https://github.com/user-attachments/assets/903be731-0d4b-433e-be74-19d833fcce99" />

