### PR TITLE
[issue-98] Allow all cells of one colour index to be remapped to a different colour index

### DIFF
--- a/imports/client/components/ThreadCounts.js
+++ b/imports/client/components/ThreadCounts.js
@@ -48,8 +48,8 @@ function ThreadCounts(props) {
     if (threadCounts[toColorIndex] !== undefined) {
       const confirmationText =
         toColorIndex === -1
-          ? `Empty hole is already used by ${threadCounts[toColorIndex]} threads. Are you sure you want to remap ${threadCounts[selectedColorIndex]} threads to empty hole? This change cannot be undone.`
-          : `Colour #${toColorIndex + 1} is already used by ${threadCounts[toColorIndex]} threads. Are you sure you want to remap ${threadCounts[selectedColorIndex]} threads to this colour? This change cannot be undone.`;
+          ? `Empty hole is already used by ${threadCounts[toColorIndex]} threads. Are you sure you want to change ${threadCounts[selectedColorIndex]} threads to empty hole? This action cannot be undone.`
+          : `Colour #${toColorIndex + 1} is already used by ${threadCounts[toColorIndex]} threads. Are you sure you want to change ${threadCounts[selectedColorIndex]} threads to this colour? This action cannot be undone.`;
 
       const confirmed = window.confirm(confirmationText);
 

--- a/imports/client/components/ThreadCounts.js
+++ b/imports/client/components/ThreadCounts.js
@@ -44,6 +44,19 @@ function ThreadCounts(props) {
   };
 
   const handleSelectNewColor = (toColorIndex) => {
+    // If the target colour is already in use, ask for confirmation before merging
+    if (threadCounts[toColorIndex] !== undefined) {
+      const confirmationText =
+        toColorIndex === -1
+          ? `Empty hole is already used by ${threadCounts[toColorIndex]} threads. Are you sure you want to remap ${threadCounts[selectedColorIndex]} threads to empty hole? This change cannot be undone.`
+          : `Colour #${toColorIndex + 1} is already used by ${threadCounts[toColorIndex]} threads. Are you sure you want to remap ${threadCounts[selectedColorIndex]} threads to this colour? This change cannot be undone.`;
+
+      const confirmed = window.confirm(confirmationText);
+
+      if (!confirmed) {
+        return;
+      }
+    }
     dispatch(
       replaceColorInThreading({
         _id,

--- a/imports/client/modules/pattern.js
+++ b/imports/client/modules/pattern.js
@@ -3994,8 +3994,8 @@ export default function pattern(state = initialPatternState, action) {
         threadingByTablet,
       } = state;
 
-      const remapThreadingByTablet = (tbt) =>
-        tbt.map((tabletColors) =>
+      const remapThreadingByTablet = (threadingByTablet) =>
+        threadingByTablet.map((tabletColors) =>
           tabletColors.map((colorIndex) =>
             colorIndex === fromColorIndex ? toColorIndex : colorIndex,
           ),

--- a/imports/client/modules/pattern.js
+++ b/imports/client/modules/pattern.js
@@ -3986,17 +3986,45 @@ export default function pattern(state = initialPatternState, action) {
 
     case REPLACE_COLOR_IN_THREADING: {
       const { fromColorIndex, toColorIndex } = action.payload;
-      const { patternDesign, patternType, threadingByTablet } = state;
+      const {
+        leftBorder,
+        patternDesign,
+        patternType,
+        rightBorder,
+        threadingByTablet,
+      } = state;
 
-      const newThreadingByTablet = threadingByTablet.map((tabletColors) =>
-        tabletColors.map((colorIndex) =>
-          colorIndex === fromColorIndex ? toColorIndex : colorIndex,
-        ),
-      );
+      const remapThreadingByTablet = (tbt) =>
+        tbt.map((tabletColors) =>
+          tabletColors.map((colorIndex) =>
+            colorIndex === fromColorIndex ? toColorIndex : colorIndex,
+          ),
+        );
+
+      const newThreadingByTablet = remapThreadingByTablet(threadingByTablet);
 
       const stateUpdate = {
         threadingByTablet: updeep.constant(newThreadingByTablet),
       };
+
+      // Also remap border threading in Redux state
+      if (leftBorder && leftBorder.threadingByTablet) {
+        stateUpdate.leftBorder = updeep.constant({
+          ...leftBorder,
+          threadingByTablet: remapThreadingByTablet(
+            leftBorder.threadingByTablet,
+          ),
+        });
+      }
+
+      if (rightBorder && rightBorder.threadingByTablet) {
+        stateUpdate.rightBorder = updeep.constant({
+          ...rightBorder,
+          threadingByTablet: remapThreadingByTablet(
+            rightBorder.threadingByTablet,
+          ),
+        });
+      }
 
       // For freehand patterns, also remap threadColor in the freehandChart
       if (

--- a/server/methods/patternEdit.js
+++ b/server/methods/patternEdit.js
@@ -1871,6 +1871,21 @@ Meteor.methods({
           }
         }
 
+        // Also update border threading arrays (leftBorder and rightBorder)
+        for (const borderKey of ['leftBorder', 'rightBorder']) {
+          const border = pattern[borderKey];
+          if (border && border.threading && border.numberOfTablets > 0) {
+            for (let hole = 0; hole < border.threading.length; hole += 1) {
+              for (let t = 0; t < border.threading[hole].length; t += 1) {
+                if (border.threading[hole][t] === fromColorIndex) {
+                  replaceUpdate[`${borderKey}.threading.${hole}.${t}`] =
+                    toColorIndex;
+                }
+              }
+            }
+          }
+        }
+
         if (Object.keys(replaceUpdate).length === 0) {
           return;
         }

--- a/server/test/02a methods.pattern.edit.test.js
+++ b/server/test/02a methods.pattern.edit.test.js
@@ -148,6 +148,34 @@ if (Meteor.isServer) {
         assert.equal(updated.threading[0][0], 3);
       });
 
+      it('replaceColorInThreading updates main pattern threading', async () => {
+        const { patternId } = this;
+
+        // First set a known colour so we can remap it
+        await callMethodWithUser(this.currentUser._id, 'pattern.edit', {
+          _id: patternId,
+          data: {
+            type: 'editThreadingCell',
+            holesToSet: [0],
+            tablet: 0,
+            colorIndex: 3,
+          },
+        });
+
+        await callMethodWithUser(this.currentUser._id, 'pattern.edit', {
+          _id: patternId,
+          data: {
+            type: 'replaceColorInThreading',
+            fromColorIndex: 3,
+            toColorIndex: 5,
+          },
+        });
+
+        const updated = await Patterns.findOneAsync({ _id: patternId });
+
+        assert.equal(updated.threading[0][0], 5);
+      });
+
       describe('border operations', () => {
         beforeEach(async () => {
           const pattern = await createBrokenTwillPattern({
@@ -571,6 +599,56 @@ if (Meteor.isServer) {
           assert.equal(updated.leftBorder.weavingInstructions.length, 4);
           // Each row should still have one entry per border tablet
           assert.equal(updated.leftBorder.weavingInstructions[0].length, 2);
+        });
+
+        it('replaceColorInThreading also updates left and right border threading', async () => {
+          const { brokenTwillPatternId } = this;
+
+          // Add a left border with colorIndex 0
+          await callMethodWithUser(this.currentUser._id, 'pattern.edit', {
+            _id: brokenTwillPatternId,
+            data: {
+              type: 'addLeftBorderTablets',
+              colorIndex: 0,
+              insertNTablets: 2,
+              insertTabletsAt: 0,
+            },
+          });
+
+          // Add a right border with colorIndex 0
+          await callMethodWithUser(this.currentUser._id, 'pattern.edit', {
+            _id: brokenTwillPatternId,
+            data: {
+              type: 'addRightBorderTablets',
+              colorIndex: 0,
+              insertNTablets: 1,
+              insertTabletsAt: 0,
+            },
+          });
+
+          // Remap colorIndex 0 → 1 (affects both borders; main threading has [[1]] so no changes there)
+          await callMethodWithUser(this.currentUser._id, 'pattern.edit', {
+            _id: brokenTwillPatternId,
+            data: {
+              type: 'replaceColorInThreading',
+              fromColorIndex: 0,
+              toColorIndex: 1,
+            },
+          });
+
+          const updated = await Patterns.findOneAsync({
+            _id: brokenTwillPatternId,
+          });
+
+          // Left border threading should be updated: all 0s → all 1s
+          assert.deepEqual(updated.leftBorder.threading[0], [1, 1]);
+          assert.deepEqual(updated.leftBorder.threading[1], [1, 1]);
+
+          // Right border threading should be updated: 0 → 1
+          assert.deepEqual(updated.rightBorder.threading[0], [1]);
+
+          // Main pattern threading should be unchanged (it had [[1]], no 0s)
+          assert.equal(updated.threading[0][0], 1);
         });
       });
     });

--- a/server/test/10_utils.test.js
+++ b/server/test/10_utils.test.js
@@ -129,10 +129,11 @@ describe('utils.js basic unit tests', () => {
     it('should pass check for valid row numbers', () => {
       expect(() => check(0, utils.validRowsCheck)).to.not.throw();
       expect(() => check(199, utils.validRowsCheck)).to.not.throw();
+      expect(() => check(200, utils.validRowsCheck)).to.not.throw();
     });
     it('should fail check for invalid row numbers', () => {
       expect(() => check(-1, utils.validRowsCheck)).to.throw();
-      expect(() => check(200, utils.validRowsCheck)).to.throw();
+      expect(() => check(201, utils.validRowsCheck)).to.throw();
     });
   });
 
@@ -275,7 +276,7 @@ describe('utils.js basic unit tests', () => {
 
     it('should return error if verified user has reached pattern limit', async () => {
       const user = await stubUser({ roles: ['registered', 'verified'] });
-      for (let i = 0; i < 100; i++) {
+      for (let i = 0; i < 150; i++) {
         await createPatternForUser(user);
       }
       const result = await utils.checkUserCanCreatePattern(user._id);


### PR DESCRIPTION
- Update pattern borders when thread colours are changed
- Warn user before changing a colour to a colour that is already in use, because this loses pattern information and cannot easily undone.