### PR TITLE
[#105] Very slow search queries in Mongo

### DIFF
--- a/imports/server/modules/searchPublications.js
+++ b/imports/server/modules/searchPublications.js
@@ -69,6 +69,25 @@ Meteor.startup(async () => {
       { background: true },
     );
 
+    // Compound indexes for common Patterns query patterns
+    // These optimize queries that filter by isPublic + numberOfTablets and sort by nameSort or createdAt
+    await Patterns.rawCollection().createIndex(
+      { isPublic: 1, numberOfTablets: 1, nameSort: 1 },
+      { background: true },
+    );
+    await Patterns.rawCollection().createIndex(
+      { isPublic: 1, numberOfTablets: 1, createdAt: -1 },
+      { background: true },
+    );
+    await Patterns.rawCollection().createIndex(
+      { isPublic: 1, isTwistNeutral: 1, numberOfTablets: 1, nameSort: 1 },
+      { background: true },
+    );
+    await Patterns.rawCollection().createIndex(
+      { isPublic: 1, isTwistNeutral: 1, numberOfTablets: 1, createdAt: -1 },
+      { background: true },
+    );
+
     // ColorBooks
     await ColorBooks.rawCollection().createIndex(
       { createdAt: 1 },

--- a/server/test/09_indexes.test.js
+++ b/server/test/09_indexes.test.js
@@ -42,6 +42,13 @@ if (Meteor.isServer) {
       const hasIndex = (info, fieldName) =>
         Object.keys(info).some((k) => k.indexOf(fieldName) !== -1);
 
+      // check compound indexes exist by field names in order
+      const hasCompoundIndex = (info, ...fieldNames) => {
+        const pattern = fieldNames.join('.*');
+        const regex = new RegExp(pattern);
+        return Object.keys(info).some((k) => regex.test(k));
+      };
+
       assert.isTrue(
         hasIndex(patternsInfo, 'createdAt'),
         'Patterns should have createdAt index',
@@ -53,6 +60,36 @@ if (Meteor.isServer) {
       assert.isTrue(
         hasIndex(patternsInfo, 'tags') || hasIndex(patternsInfo, 'tags_'),
         'Patterns should have tags index',
+      );
+
+      // Verify critical compound indexes for query performance
+      assert.isTrue(
+        hasCompoundIndex(patternsInfo, 'isPublic', 'numberOfTablets', 'nameSort'),
+        'Patterns should have isPublic+numberOfTablets+nameSort compound index',
+      );
+      assert.isTrue(
+        hasCompoundIndex(patternsInfo, 'isPublic', 'numberOfTablets', 'createdAt'),
+        'Patterns should have isPublic+numberOfTablets+createdAt compound index',
+      );
+      assert.isTrue(
+        hasCompoundIndex(
+          patternsInfo,
+          'isPublic',
+          'isTwistNeutral',
+          'numberOfTablets',
+          'nameSort',
+        ),
+        'Patterns should have isPublic+isTwistNeutral+numberOfTablets+nameSort compound index',
+      );
+      assert.isTrue(
+        hasCompoundIndex(
+          patternsInfo,
+          'isPublic',
+          'isTwistNeutral',
+          'numberOfTablets',
+          'createdAt',
+        ),
+        'Patterns should have isPublic+isTwistNeutral+numberOfTablets+createdAt compound index',
       );
 
       assert.isTrue(


### PR DESCRIPTION
Added compound indexes to persist those that have been added directly on the server, to speed up slow queries in Mongodb.